### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,7 +27,7 @@ class ItemsController < ApplicationController
   def update
 
     if @item.update(item_params)
-      redirect_to @item
+      redirect_to item_path(@item)
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
 
-  before_action :require_login, only: [:new]
+  before_action :require_login, only: [:new, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :redirect_unless_owner, only: [:edit, :update]
 
 
   
@@ -17,23 +19,31 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])  
-
   end
   
   def edit
-    @item = Item.find(params[:id])
   end
   
-  #def update
-    #@item = Item.find(params[:id])
-  
-   # if @item.update(item_params)
-      #redirect_to @item, notice: '商品情報が更新されました。'
-    #else
-      #render :edit
-    #end
-  #end
+  def update
+
+    if @item.update(item_params)
+      redirect_to @item
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
+  rescue ActiveRecord::RecordNotFound 
+    redirect_to root_path
+  end
+
+  def redirect_unless_owner
+    if current_user && @item.user_id != current_user.id
+      redirect_to root_path
+    end
+  end
   
   #def destroy
     #@item = Item.find(params[:id])

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -21,9 +21,9 @@ class ItemsController < ApplicationController
 
   end
   
-  #def edit
-   # @item = Item.find(params[:id])
-  #end
+  def edit
+    @item = Item.find(params[:id])
+  end
   
   #def update
     #@item = Item.find(params[:id])

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,19 +18,19 @@ class Item < ApplicationRecord
   validates :explanation, presence: {message: "can't be blank"}
 
   # カテゴリーの情報が必須
-  validates :category_id, presence: {message: "Category must be selected"}, numericality: { other_than: 0 }
+  validates :category_id, presence: {message: "Category must be selected"}, numericality: { other_than: 1 }
 
   # 商品の状態の情報が必須
-  validates :condition_id, presence: {message: "Condition must be selected"}, numericality: { other_than: 0 }
+  validates :condition_id, presence: {message: "Condition must be selected"}, numericality: { other_than: 1 }
 
   # 配送料の負担の情報が必須
-  validates :shopping_fee_id, presence: {message: "Shopping fee must be selected"}, numericality: { other_than: 0 }
+  validates :shopping_fee_id, presence: {message: "Shopping fee must be selected"}, numericality: { other_than: 1 }
 
   # 発送元の地域の情報が必須
-  validates :prefecture_id, presence: {message: "Prefecture must be selected"}, numericality: { other_than: 0 }
+  validates :prefecture_id, presence: {message: "Prefecture must be selected"}, numericality: { other_than: 1 }
 
   # 発送までの日数の情報が必須
-  validates :shopping_duration_id, presence: {message: "Shopping duration must be selected"}, numericality: { other_than: 0 }
+  validates :shopping_duration_id, presence: {message: "Shopping duration must be selected"}, numericality: { other_than: 1 }
 
   # 価格の情報が必須
   validates :price, presence: {message: "can't be blank"}

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,7 +9,9 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item,local: true do |f| %>
 
-    <% render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
+
+
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -116,6 +118,31 @@ app/assets/stylesheets/items/new.css %>
       </div>
     </div>
     <%# /販売価格 %>
+    <script>
+  // 販売価格の入力欄が変更されたときに実行される関数
+  function calculateCommissionAndProfit() {
+    const priceInput = document.getElementById('item-price');
+    const addTaxPriceSpan = document.getElementById('add-tax-price');
+    const profitSpan = document.getElementById('profit');
+
+    // 入力された価格を整数に変換
+    const price = parseInt(priceInput.value, 10);
+
+    // 販売手数料の計算（価格の10%を計算し、小数点以下を切り捨て）
+    const commission = Math.floor(price * 0.1);
+
+    // 販売利益の計算（価格から販売手数料を引いた金額）
+    const profit = price - commission;
+
+    // 計算結果を表示
+    addTaxPriceSpan.textContent = commission.toLocaleString();
+    profitSpan.textContent = profit.toLocaleString();
+  }
+
+  // 販売価格の入力欄が変更されたときにcalculateCommissionAndProfit関数を呼び出す
+  const priceInput = document.getElementById('item-price');
+  priceInput.addEventListener('input', calculateCommissionAndProfit);
+  </script>
 
     <%# 注意書き %>
     <div class="caution">
@@ -139,7 +166,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item,local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <% render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :explanation, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select :category_id, Category.all, :id, :name, {}, class:"select-box", id:"item-category" %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select :condition_id, Condition.all, :id, :name, {}, class:"select-box", id:"item-sales-status" %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select :shopping_fee_id, Condition.all, :id, :name, {}, class:"select-box", id:"item-shipping-fee-status" %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, class:"select-box", id:"item-prefecture" %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select :shopping_duration_id, Shoppingduration.all, :id, :name, {}, class:"select-box", id:"item-scheduled-delivery" %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
 
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id %>
-        <%#= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%#= link_to "削除", item_path(@item), method: :delete, class:"item-destroy" %>
     


### PR DESCRIPTION
### what
出品した商品の編集機能の追加

### why
商品の編集を追加するため

[ ログイン状態の出品者は、商品情報編集ページに遷移できる動画](https://gyazo.com/5df773ec304e8c9c5bf765f3fb21a8f1)

[ 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画](https://gyazo.com/dc3e464aed290bab2338bd5f830d895d)

[ 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画](https://gyazo.com/581458342ad640c75eee4098c945f45f)

[ 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画](https://gyazo.com/5f266e1a356347586fe74a54a1c180a1)

[ ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画](https://gyazo.com/0f38ebd7154b72c21ce48a72ad8be3fa)

[ ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画](https://gyazo.com/3f952aa662b4c69ebceeae595f9ab63b)

[ 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）](https://gyazo.com/61abed4d46042feb0aa03a7ed35c71ac)